### PR TITLE
Remove backend.tf.aws-s3.example and Release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Terraform project for account bootstrapping on dxw's Dalmatian hosting platform
 
 [![Terraform CI](https://github.com/dxw/terraform-dxw-dalmatian-account-bootstrap/actions/workflows/continuous-integration-terraform.yml/badge.svg?branch=main)](https://github.com/dxw/terraform-dxw-dalmatian-account-bootstrap/actions/workflows/continuous-integration-terraform.yml?branch=main)
-[![GitHub release](./releases)](https://github.com/dxw/terraform-dxw-dalmatian-account-bootstrap/releases)
 
 This project creates and manages resources within an AWS account to bootstrap it
 for dxw's Dalmatian hosting platform.

--- a/backend.tf.aws-s3.example
+++ b/backend.tf.aws-s3.example
@@ -1,8 +1,0 @@
-terraform {
-  backend "s3" {
-    bucket  = "<bucket-name>"
-    key     = "terraform.tfstate"
-    region  = "<region>"
-    encrypt = "true"
-  }
-}


### PR DESCRIPTION
* We don't need the example backend.tf, and we won't be creating releases for this project