### PR TITLE
Add terraform-aws-tfvars-s3 module

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ No resources.
 
 ## Inputs
 
-No inputs.
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name to be used as a prefix for all resources | `string` | n/a | yes |
+| <a name="input_tfvars_s3_enable_s3_bucket_logging"></a> [tfvars\_s3\_enable\_s3\_bucket\_logging](#input\_tfvars\_s3\_enable\_s3\_bucket\_logging) | Enable S3 bucket logging on the tfvars S3 bucket | `bool` | n/a | yes |
+| <a name="input_tfvars_s3_logging_bucket_retention"></a> [tfvars\_s3\_logging\_bucket\_retention](#input\_tfvars\_s3\_logging\_bucket\_retention) | tfvars S3 Logging bucket retention in days. Set to 0 to keep all logs. | `number` | n/a | yes |
 
 ## Outputs
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,2 +1,5 @@
 locals {
+  project_name                       = var.project_name
+  tfvars_s3_enable_s3_bucket_logging = var.tfvars_s3_enable_s3_bucket_logging
+  tfvars_s3_logging_bucket_retention = var.tfvars_s3_logging_bucket_retention
 }

--- a/s3-tfvars.tf
+++ b/s3-tfvars.tf
@@ -1,0 +1,9 @@
+module "aws_tfvars_s3" {
+  # This module currently doesn't have a Release
+  # tflint-ignore: terraform_module_pinned_source
+  source = "github.com/dxw/terraform-aws-tfvars-s3?ref=main"
+
+  project_name             = local.project_name
+  enable_s3_bucket_logging = local.tfvars_s3_enable_s3_bucket_logging
+  logging_bucket_retention = local.tfvars_s3_logging_bucket_retention
+}

--- a/tfvars.example
+++ b/tfvars.example
@@ -1,0 +1,3 @@
+project_name                       = "my-project"
+tfvars_s3_enable_s3_bucket_logging = true
+tfvars_s3_logging_bucket_retention = 30

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,14 @@
+variable "project_name" {
+  description = "Project name to be used as a prefix for all resources"
+  type        = string
+}
+
+variable "tfvars_s3_enable_s3_bucket_logging" {
+  description = "Enable S3 bucket logging on the tfvars S3 bucket"
+  type        = bool
+}
+
+variable "tfvars_s3_logging_bucket_retention" {
+  description = "tfvars S3 Logging bucket retention in days. Set to 0 to keep all logs."
+  type        = number
+}


### PR DESCRIPTION
* This module will be used to store the terraform variables within a secure S3 bucket, so that they can be kept up to date in a centralised location to be shared with the project team.
* The module currently has no releases, so `main` is currently being used.