### PR TITLE
Create project name hash

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,6 @@
 locals {
   project_name                       = var.project_name
+  project_name_hash                  = format("%.6s", sha1(local.project_name))
   aws_region                         = var.aws_region
   tfvars_s3_enable_s3_bucket_logging = var.tfvars_s3_enable_s3_bucket_logging
   tfvars_s3_logging_bucket_retention = var.tfvars_s3_logging_bucket_retention

--- a/s3-tfvars.tf
+++ b/s3-tfvars.tf
@@ -3,7 +3,7 @@ module "aws_tfvars_s3" {
   # tflint-ignore: terraform_module_pinned_source
   source = "github.com/dxw/terraform-aws-tfvars-s3?ref=main"
 
-  project_name             = local.project_name
+  project_name             = local.project_name_hash
   enable_s3_bucket_logging = local.tfvars_s3_enable_s3_bucket_logging
   logging_bucket_retention = local.tfvars_s3_logging_bucket_retention
 }


### PR DESCRIPTION
* A lot of resources within AWS have reletively short name length requirements. This creates a hash of `project_name`, using sha1, and then cuts it to 5 characters, stored as `local.project_name_hash`
* The full `project_name` is added as a tag