### PR TITLE
Include modules in terraform-docs

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,9 +1,6 @@
 ---
 formatter: "markdown table"
 version: "~> 0.16"
-sections:
-  hide:
-    - modules
 settings:
   anchor: true
   default: true

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ for dxw's Dalmatian hosting platform.
 
 No providers.
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_aws_tfvars_s3"></a> [aws\_tfvars\_s3](#module\_aws\_tfvars\_s3) | github.com/dxw/terraform-aws-tfvars-s3 | main |
+
 ## Resources
 
 No resources.


### PR DESCRIPTION
* They are hidden by default in the terraform template