### PR TITLE
Add CloudWatch Slack alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ override.tf.json
 *_override.tf
 *_override.tf.json
 backend.vars
+
+# caches
+lambdas/.zip-cache/*

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,23 +1,45 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.4.0"
+  constraints = ">= 2.4.0"
+  hashes = [
+    "h1:ZtsrX5F13Ohsv/k/BvgyBVn0gF+lW4bkG7JmCGrN35Y=",
+    "zh:18e408596dd53048f7fc8229098d0e3ad940b92036a24287eff63e2caec72594",
+    "zh:392d4216ecd1a1fd933d23f4486b642a8480f934c13e2cae3c13b6b6a7e34a7b",
+    "zh:655dd1fa5ca753a4ace21d0de3792d96fff429445717f2ce31c125d19c38f3ff",
+    "zh:70dae36c176aa2b258331ad366a471176417a94dd3b4985a911b8be9ff842b00",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7d8c8e3925f1e21daf73f85983894fbe8868e326910e6df3720265bc657b9c9c",
+    "zh:a032ec0f0aee27a789726e348e8ad20778c3a1c9190ef25e7cff602c8d175f44",
+    "zh:b8e50de62ba185745b0fe9713755079ad0e9f7ac8638d204de6762cc36870410",
+    "zh:c8ad0c7697a3d444df21ff97f3473a8604c8639be64afe3f31b8ec7ad7571e18",
+    "zh:df736c5a2a7c3a82c5493665f659437a22f0baf8c2d157e45f4dd7ca40e739fc",
+    "zh:e8ffbf578a0977074f6d08aa8734e36c726e53dc79894cfc4f25fadc4f45f1df",
+    "zh:efea57ff23b141551f92b2699024d356c7ffd1a4ad62931da7ed7a386aef7f1f",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.12.0"
-  constraints = ">= 5.9.0"
+  constraints = ">= 5.9.0, >= 5.11.0"
   hashes = [
-    "h1:3Gchmc4oyFvWh3B4tEOQN5UOCd0bfp0P4fEgdpatmlo=",
-    "h1:4GV65EQN0ao20xQ8O/fqHWwl4Xv2sLayOYVzTUKH49Q=",
-    "h1:8GIYLZY/iHTv2MegJg+hcHMC60vRLXfu//oqQoql3IY=",
-    "h1:9V+bzwGRcstnaQPfGcw7u7gDztdA9XqBkZ6GAphhnpw=",
-    "h1:DXVAP/PgKZ/pBZqAdvrb8I97HexX8WVtK3vZsxc4dgc=",
-    "h1:EfFnhFsZ1XO/r5HBUXII7ywR47tDops+QrKWY0II3QY=",
     "h1:GWmoet1icv68bVcTQ4EGOCUUJ5vbyhzubL8Y3c7Se+Q=",
-    "h1:L2XsXdB8SJB/lTQnFRVd62boC44ovzIl6GZqNpAvVik=",
-    "h1:fM2RVYckgL0K5Qh5UIH3bFouC0dCvQbKbJJuOP2qW1k=",
-    "h1:i28TUsgqoKs891cyDU0V9fFAwEz/RqbwF8sQShLfNq0=",
-    "h1:o08bX296gc5lJ6dCQazh9mfxEGY08NX81VSeebmmKZk=",
-    "h1:pxx71bfqKRTjUvLqcSEpgpCV4f2uvNHca4X0OOSu+mU=",
-    "h1:uw1ZfMHufDCC1ftzczNHofmRIB+E+8aWvyrLsdclVtA=",
-    "h1:y7hzOYM6A7/eaRHfFVhk/gWh0/Bl7Kj/6/UB3DE6u9M=",
+    "zh:0953565eb67ece49556dc9046c77322dc6c76e0ae6fa0c9fd6710b6afa2588c9",
+    "zh:43676f3592c127a971719cc37b9199967376fb05d445b356f1545609e2b84bf8",
+    "zh:46422ab8044b35e90f422ffabc17fa043ec8e4a33e3df2f8b305d63a950c0edb",
+    "zh:4d34f024a82d31d10b5a9498d26fca71e3e35c543dfc5185c94c3205bc4dba22",
+    "zh:51be0eeb882f041fc2679bd621e64cd775d013ae003055cea013c9d630c15dfb",
+    "zh:7ca9252befa7271899febde25b679a73f90dbdb700cbbfec07d29389a3937131",
+    "zh:8325b2152be0534a718e497a3273cf6c42880e78f290dc35024feef2e0af8e97",
+    "zh:98f0c4d4c190cf4897cb9075a538f42f2998566e9f2d15755901fbb4862f8b32",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a71e0bc6754bb3924b31727d80f05b04fa65247c009ffdfd2a715a01d95b373d",
+    "zh:a82ae67ce3d4c7aaae761a592275b8cac5e9965a30b2dba951c1d965b3121006",
+    "zh:c5510eca023cec89557a8244648bf8ad9a0cd3189b6abf6dcceba30e3b2e8c6d",
+    "zh:cd11fe9c83793e838b6f90a55840fc45e7c106b358a68f0a88db09a29a321c9a",
+    "zh:e451ad353f219a2922b92e786a93c31658168b896317be127798cddfa9a99363",
+    "zh:e4b70a70e925b9ccb7d44e17fd8e7b89aa744a965f298f8bb2480a5c96f3c4f0",
   ]
 }

--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ for dxw's Dalmatian hosting platform.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.9.0 |
+| <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.11.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.4.0 |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.12.0 |
 
 ## Modules
@@ -33,15 +35,25 @@ for dxw's Dalmatian hosting platform.
 |------|------|
 | [aws_cloudtrail.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail) | resource |
 | [aws_cloudwatch_log_group.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_group.cloudwatch_slack_alerts_lambda_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_iam_policy.cloudtrail_cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.cloudtrail_cloudwatch_logs_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.cloudtrail_cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.cloudwatch_slack_alerts_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.cloudtrail_cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cloudtrail_cloudwatch_logs_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lambda_function.cloudwatch_slack_alerts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_permission.cloudwatch_slack_alerts_sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_s3_bucket.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_lifecycle_configuration.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_policy.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_sns_topic.cloudwatch_slack_alerts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic_policy.sns_cloudwatch_slack_alerts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_policy) | resource |
+| [aws_sns_topic_subscription.cloudwatch_slack_alerts_lambda_subscription](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
+| [archive_file.cloudwatch_slack_alerts_lambda](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 
 ## Inputs
@@ -51,7 +63,10 @@ for dxw's Dalmatian hosting platform.
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region in which to launch resources | `string` | n/a | yes |
 | <a name="input_cloudtrail_log_prefix"></a> [cloudtrail\_log\_prefix](#input\_cloudtrail\_log\_prefix) | Cloudtrail log prefix | `string` | n/a | yes |
 | <a name="input_cloudtrail_log_retention"></a> [cloudtrail\_log\_retention](#input\_cloudtrail\_log\_retention) | Cloudtrail log retention in days. Set to 0 to keep all logs. | `number` | n/a | yes |
+| <a name="input_cloudwatch_slack_alerts_channel"></a> [cloudwatch\_slack\_alerts\_channel](#input\_cloudwatch\_slack\_alerts\_channel) | The Slack channel for CloudWatch alerts | `string` | n/a | yes |
+| <a name="input_cloudwatch_slack_alerts_hook_url"></a> [cloudwatch\_slack\_alerts\_hook\_url](#input\_cloudwatch\_slack\_alerts\_hook\_url) | The Slack webhook URL for CloudWatch alerts | `string` | n/a | yes |
 | <a name="input_enable_cloudtrail"></a> [enable\_cloudtrail](#input\_enable\_cloudtrail) | Enable Cloudtrail | `bool` | n/a | yes |
+| <a name="input_enable_cloudwatch_slack_alerts"></a> [enable\_cloudwatch\_slack\_alerts](#input\_enable\_cloudwatch\_slack\_alerts) | Enable CloudWatch Slack alerts. This creates an SNS topic to which alerts and pipelines can send messages, which are then picked up by a Lambda function that forwards them to a Slack webhook. | `bool` | n/a | yes |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name to be used as a prefix for all resources | `string` | n/a | yes |
 | <a name="input_tfvars_s3_enable_s3_bucket_logging"></a> [tfvars\_s3\_enable\_s3\_bucket\_logging](#input\_tfvars\_s3\_enable\_s3\_bucket\_logging) | Enable S3 bucket logging on the tfvars S3 bucket | `bool` | n/a | yes |
 | <a name="input_tfvars_s3_logging_bucket_retention"></a> [tfvars\_s3\_logging\_bucket\_retention](#input\_tfvars\_s3\_logging\_bucket\_retention) | tfvars S3 Logging bucket retention in days. Set to 0 to keep all logs. | `number` | n/a | yes |

--- a/cloudwatch-slack-alerts-lambda.tf
+++ b/cloudwatch-slack-alerts-lambda.tf
@@ -1,0 +1,76 @@
+resource "aws_cloudwatch_log_group" "cloudwatch_slack_alerts_lambda_log_group" {
+  count = local.enable_cloudwatch_slack_alerts ? 1 : 0
+
+  name = "/aws/lambda/${local.project_name}-cloudwatch-to-slack"
+}
+
+resource "aws_iam_role" "cloudwatch_slack_alerts_lambda" {
+  count = local.enable_cloudwatch_slack_alerts ? 1 : 0
+
+  name = "${local.project_name}-cloudwatch-slack-alerts-lambda"
+  assume_role_policy = templatefile(
+    "${path.root}/policies/service-assume.json.tpl",
+    { service = "lambda.amazonaws.com" }
+  )
+}
+
+resource "aws_iam_policy" "cloudtrail_cloudwatch_logs_lambda" {
+  count = local.enable_cloudwatch_slack_alerts ? 1 : 0
+
+  name = "${local.project_name}-cloudwatch-slack-alerts-lambda"
+  policy = templatefile(
+    "${path.root}/policies/lambda-default.json.tpl",
+    {
+      region        = local.aws_region
+      account_id    = local.aws_account_id
+      function_name = "${local.project_name}-cloudwatch-slack-alerts"
+    }
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "cloudtrail_cloudwatch_logs_lambda" {
+  count = local.enable_cloudwatch_slack_alerts ? 1 : 0
+
+  role       = aws_iam_role.cloudwatch_slack_alerts_lambda[0].name
+  policy_arn = aws_iam_policy.cloudtrail_cloudwatch_logs_lambda[0].arn
+}
+
+data "archive_file" "cloudwatch_slack_alerts_lambda" {
+  count = local.enable_cloudwatch_slack_alerts ? 1 : 0
+
+  type        = "zip"
+  source_dir  = "lambdas/cloudwatch-slack-alerts"
+  output_path = "lambdas/.zip-cache/cloudwatch-slack-alerts.zip"
+}
+
+resource "aws_lambda_function" "cloudwatch_slack_alerts" {
+  count = local.enable_cloudwatch_slack_alerts ? 1 : 0
+
+  filename         = data.archive_file.cloudwatch_slack_alerts_lambda[0].output_path
+  function_name    = "${local.project_name}-cloudwatch-slack-alerts"
+  description      = "${local.project_name} CloudWatch Slack Alerts"
+  handler          = "function.lambda_handler"
+  runtime          = "python3.11"
+  role             = aws_iam_role.cloudwatch_slack_alerts_lambda[0].arn
+  source_code_hash = data.archive_file.cloudwatch_slack_alerts_lambda[0].output_base64sha256
+  memory_size      = 128
+  package_type     = "Zip"
+  timeout          = 30
+
+  environment {
+    variables = {
+      slackHookUrl = local.cloudwatch_slack_alerts_hook_url
+      slackChannel = local.cloudwatch_slack_alerts_channel
+    }
+  }
+}
+
+resource "aws_lambda_permission" "cloudwatch_slack_alerts_sns" {
+  count = local.enable_cloudwatch_slack_alerts ? 1 : 0
+
+  statement_id  = "AllowExecutionFromSNS"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.cloudwatch_slack_alerts[0].arn
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.cloudwatch_slack_alerts[0].arn
+}

--- a/cloudwatch-slack-alerts-sns.tf
+++ b/cloudwatch-slack-alerts-sns.tf
@@ -1,0 +1,26 @@
+resource "aws_sns_topic" "cloudwatch_slack_alerts" {
+  count = local.enable_cloudwatch_slack_alerts ? 1 : 0
+
+  name = "${local.project_name}-cloudwatch-slack-alerts"
+}
+
+resource "aws_sns_topic_policy" "sns_cloudwatch_slack_alerts" {
+  count = local.enable_cloudwatch_slack_alerts ? 1 : 0
+
+  arn = aws_sns_topic.cloudwatch_slack_alerts[0].arn
+  policy = templatefile(
+    "${path.root}/policies/sns-events-policy.json.tpl",
+    {
+      sns_arn        = aws_sns_topic.cloudwatch_slack_alerts[0].arn
+      aws_account_id = local.aws_account_id
+    }
+  )
+}
+
+resource "aws_sns_topic_subscription" "cloudwatch_slack_alerts_lambda_subscription" {
+  count = local.enable_cloudwatch_slack_alerts ? 1 : 0
+
+  topic_arn = aws_sns_topic.cloudwatch_slack_alerts[0].arn
+  protocol  = "lambda"
+  endpoint  = aws_lambda_function.cloudwatch_slack_alerts[0].arn
+}

--- a/lambdas/cloudwatch-slack-alerts/function.py
+++ b/lambdas/cloudwatch-slack-alerts/function.py
@@ -1,0 +1,99 @@
+import boto3
+import json
+import logging
+import os
+
+from urllib.request import Request, urlopen
+from urllib.error import URLError, HTTPError
+
+SLACK_CHANNEL = os.environ['slackChannel']
+HOOK_URL = os.environ['slackHookUrl']
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+def lambda_handler(event, context):
+    logger.info("Event: " + str(event))
+    message = json.loads(event['Records'][0]['Sns']['Message'])
+    logger.info("Message: " + str(message))
+
+    if "AlarmName" in message.keys():
+      alarm_name = message['AlarmName']
+      new_state = message['NewStateValue']
+      reason = message['NewStateReason']
+      if new_state == "OK":
+        message_color = "good"
+      else:
+        message_color = "danger"
+      slack_message = {
+        'channel': SLACK_CHANNEL,
+        'attachments': [
+          {
+            'text': "%s state is now %s:\n %s" % (alarm_name, new_state, reason),
+            'color': message_color
+          }
+        ]
+      }
+    elif "detail-type" in message.keys():
+      detail_type = message['detail-type']
+      if detail_type == "CodePipeline Pipeline Execution State Change":
+        pipeline = message['detail']['pipeline']
+        pipeline_state = message['detail']['state']
+        if pipeline_state == "FAILED":
+          message_color = "danger"
+        else:
+          message_color = "good"
+        slack_message = {
+          'channel': SLACK_CHANNEL,
+          'attachments': [
+            {
+              'text': "Pipeline %s %s" % (pipeline, pipeline_state),
+              'color': message_color
+            }
+          ]
+        }
+
+    logger.info("Event: " + str(json.dumps(slack_message)))
+    req = Request(HOOK_URL, json.dumps(slack_message).encode('utf-8'))
+    try:
+        response = urlopen(req)
+        response.read()
+        logger.info("Message posted to %s", slack_message['channel'])
+    except HTTPError as e:
+        logger.error("Request failed: %d %s", e.code, e.reason)
+    except URLError as e:
+        logger.error("Server connection failed: %s", e.reason)
+
+'''
+*Test examples*
+
+Alarm:
+{
+  "Records": [
+    {
+      "EventSource": "aws:sns",
+      "EventVersion": "1.0",
+      "Sns": {
+        "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+        "Message": "{\"AlarmName\": \"Test alarm\",\"NewStateValue\": \"OK\",\"NewStateReason\": \"Testing\"}",
+        "Timestamp": "1970-01-01T00:00:00.000Z"
+      }
+    }
+  ]
+}
+
+CodePipeline:
+{
+  "Records": [
+    {
+      "EventSource": "aws:sns",
+      "EventVersion": "1.0",
+      "Sns": {
+        "MessageId": "95df01b4-ee98-5cb9-9903-4c221d41eb5e",
+        "Message": "{\"detail-type\": \"CodePipeline Pipeline Execution State Change\",\"detail\": {\"pipeline\": \"Test pipeline\", \"state\": \"STARTED\"}}",
+        "Timestamp": "1970-01-01T00:00:00.000Z"
+      }
+    }
+  ]
+}
+'''

--- a/locals.tf
+++ b/locals.tf
@@ -13,6 +13,10 @@ locals {
   cloudtrail_log_retention = var.cloudtrail_log_retention
   cloudtrail_log_prefix    = var.cloudtrail_log_prefix
 
+  enable_cloudwatch_slack_alerts   = var.enable_cloudwatch_slack_alerts
+  cloudwatch_slack_alerts_hook_url = var.cloudwatch_slack_alerts_hook_url
+  cloudwatch_slack_alerts_channel  = var.cloudwatch_slack_alerts_channel
+
   default_tags = {
     Project = local.project_name,
   }

--- a/policies/lambda-default.json.tpl
+++ b/policies/lambda-default.json.tpl
@@ -1,0 +1,22 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup"
+      ],
+      "Resource": "arn:aws:logs:${region}:${account_id}:*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": [
+        "arn:aws:logs:${region}:${account_id}:log-group:/aws/lambda/${function_name}:*"
+      ]
+    }
+  ]
+}

--- a/policies/sns-events-policy.json.tpl
+++ b/policies/sns-events-policy.json.tpl
@@ -1,0 +1,38 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "allow-sns-source-owner",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": [
+        "SNS:GetTopicAttributes",
+        "SNS:SetTopicAttributes",
+        "SNS:AddPermission",
+        "SNS:RemovePermission",
+        "SNS:DeleteTopic",
+        "SNS:Subscribe",
+        "SNS:ListSubscriptionsByTopic",
+        "SNS:Publish",
+        "SNS:Receive"
+      ],
+      "Resource": "${sns_arn}",
+      "Condition": {
+        "StringEquals": {
+          "AWS:SourceOwner": "${aws_account_id}"
+        }
+      }
+    },
+    {
+      "Sid": "allow-sns-events-publish",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "events.amazonaws.com"
+      },
+      "Action": "sns:Publish",
+      "Resource": "${sns_arn}"
+    }
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -49,3 +49,18 @@ variable "cloudtrail_log_prefix" {
   description = "Cloudtrail log prefix"
   type        = string
 }
+
+variable "enable_cloudwatch_slack_alerts" {
+  description = "Enable CloudWatch Slack alerts. This creates an SNS topic to which alerts and pipelines can send messages, which are then picked up by a Lambda function that forwards them to a Slack webhook."
+  type        = bool
+}
+
+variable "cloudwatch_slack_alerts_hook_url" {
+  description = "The Slack webhook URL for CloudWatch alerts"
+  type        = string
+}
+
+variable "cloudwatch_slack_alerts_channel" {
+  description = "The Slack channel for CloudWatch alerts"
+  type        = string
+}

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.9.0"
+      version = ">= 5.11.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2.4.0"
     }
   }
 }


### PR DESCRIPTION
* Creates an SNS topic for CloudWatch or CodePipeline to send events to.
* Creates a Lambda function subscribed to the SNS topic, which will format and forward the event message to Slack