### PR TITLE
Conditionally enable S3 tfvars

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ for dxw's Dalmatian hosting platform.
 | <a name="input_cloudwatch_slack_alerts_hook_url"></a> [cloudwatch\_slack\_alerts\_hook\_url](#input\_cloudwatch\_slack\_alerts\_hook\_url) | The Slack webhook URL for CloudWatch alerts | `string` | n/a | yes |
 | <a name="input_enable_cloudtrail"></a> [enable\_cloudtrail](#input\_enable\_cloudtrail) | Enable Cloudtrail | `bool` | n/a | yes |
 | <a name="input_enable_cloudwatch_slack_alerts"></a> [enable\_cloudwatch\_slack\_alerts](#input\_enable\_cloudwatch\_slack\_alerts) | Enable CloudWatch Slack alerts. This creates an SNS topic to which alerts and pipelines can send messages, which are then picked up by a Lambda function that forwards them to a Slack webhook. | `bool` | n/a | yes |
+| <a name="input_enable_s3_tfvars"></a> [enable\_s3\_tfvars](#input\_enable\_s3\_tfvars) | enable\_s3\_tfvars | `bool` | n/a | yes |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name to be used as a prefix for all resources | `string` | n/a | yes |
-| <a name="input_tfvars_s3_enable_s3_bucket_logging"></a> [tfvars\_s3\_enable\_s3\_bucket\_logging](#input\_tfvars\_s3\_enable\_s3\_bucket\_logging) | Enable S3 bucket logging on the tfvars S3 bucket | `bool` | n/a | yes |
-| <a name="input_tfvars_s3_logging_bucket_retention"></a> [tfvars\_s3\_logging\_bucket\_retention](#input\_tfvars\_s3\_logging\_bucket\_retention) | tfvars S3 Logging bucket retention in days. Set to 0 to keep all logs. | `number` | n/a | yes |
+| <a name="input_tfvars_s3_enable_s3_bucket_logging"></a> [tfvars\_s3\_enable\_s3\_bucket\_logging](#input\_tfvars\_s3\_enable\_s3\_bucket\_logging) | Enable S3 bucket logging on the tfvars S3 bucket | `bool` | `true` | no |
+| <a name="input_tfvars_s3_logging_bucket_retention"></a> [tfvars\_s3\_logging\_bucket\_retention](#input\_tfvars\_s3\_logging\_bucket\_retention) | tfvars S3 Logging bucket retention in days. Set to 0 to keep all logs. | `number` | `30` | no |
 | <a name="input_tfvars_s3_tfvars_files"></a> [tfvars\_s3\_tfvars\_files](#input\_tfvars\_s3\_tfvars\_files) | Map of objects containing tfvar file paths | <pre>map(<br>    object({<br>      path = string<br>      }<br>  ))</pre> | `{}` | no |
 | <a name="input_tfvars_s3_tfvars_restrict_access_user_ids"></a> [tfvars\_s3\_tfvars\_restrict\_access\_user\_ids](#input\_tfvars\_s3\_tfvars\_restrict\_access\_user\_ids) | List of AWS User IDs that require access to the tfvars S3 bucket. If left empty, all users within the AWS account will have access | `list(string)` | `[]` | no |
 

--- a/locals.tf
+++ b/locals.tf
@@ -4,6 +4,7 @@ locals {
   aws_region        = var.aws_region
   aws_account_id    = data.aws_caller_identity.current.account_id
 
+  enable_s3_tfvars                          = var.enable_s3_tfvars
   tfvars_s3_enable_s3_bucket_logging        = var.tfvars_s3_enable_s3_bucket_logging
   tfvars_s3_logging_bucket_retention        = var.tfvars_s3_logging_bucket_retention
   tfvars_s3_tfvars_files                    = var.tfvars_s3_tfvars_files

--- a/s3-tfvars.tf
+++ b/s3-tfvars.tf
@@ -1,6 +1,8 @@
 module "aws_tfvars_s3" {
   source = "github.com/dxw/terraform-aws-tfvars-s3?ref=v0.2.1"
 
+  count = local.enable_s3_tfvars ? 1 : 0
+
   project_name                    = local.project_name_hash
   enable_s3_bucket_logging        = local.tfvars_s3_enable_s3_bucket_logging
   logging_bucket_retention        = local.tfvars_s3_logging_bucket_retention

--- a/variables.tf
+++ b/variables.tf
@@ -8,14 +8,21 @@ variable "aws_region" {
   type        = string
 }
 
+variable "enable_s3_tfvars" {
+  description = "enable_s3_tfvars"
+  type        = bool
+}
+
 variable "tfvars_s3_enable_s3_bucket_logging" {
   description = "Enable S3 bucket logging on the tfvars S3 bucket"
   type        = bool
+  default     = true
 }
 
 variable "tfvars_s3_logging_bucket_retention" {
   description = "tfvars S3 Logging bucket retention in days. Set to 0 to keep all logs."
   type        = number
+  default     = 30
 }
 
 variable "tfvars_s3_tfvars_files" {


### PR DESCRIPTION
* Allows choosing wether to create the S3 tfvars module
* Sets defaults for the S3 tfvars variables so that they don't need to be specified if the module is not enabled