### PR TITLE
Commit terraform-docs changes if branch is from Renovate

### DIFF
--- a/.github/workflows/continuous-integration-terraform.yml
+++ b/.github/workflows/continuous-integration-terraform.yml
@@ -65,9 +65,20 @@ jobs:
 
       - name: Generate Terraform docs
         uses: terraform-docs/gh-actions@v1.0.0
+        if: "!startsWith(github.ref, 'refs/heads/renovate/')"
         with:
           working-dir: .
           config-file: .terraform-docs.yml
           output-file: README.md
           output-method: inject
           fail-on-diff: true
+
+      - name: Generate Terraform docs for Renovate
+        uses: terraform-docs/gh-actions@v1.0.0
+        if: "startsWith(github.ref, 'refs/heads/renovate/')"
+        with:
+          working-dir: .
+          config-file: .terraform-docs.yml
+          output-file: README.md
+          output-method: inject
+          git-push: true

--- a/renovate.json
+++ b/renovate.json
@@ -2,13 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ],
-  "postUpdateOptions": {
-    "enabled": true,
-    "commands": [
-      "docker run --rm --volume $(pwd):/terraform-docs -w /terraform-docs -u $(id -u) quay.io/terraform-docs/terraform-docs:0.16.0 .",
-      "git add .",
-      "git commit -m '${renovateCommitMessage} - Terraform Docs'"
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
* If Renovate makes changes to Terraform dependencies, the terraform docs workflow fails because the documentation hasn't been updated.
* This adds a new step, to run terraform-docs and push the changes.
* This also reverts the attempt to get Renovate to run a command after it has made it's updates.