### PR TITLE
Fix terraform-docs workflow branch name check

### DIFF
--- a/.github/workflows/continuous-integration-terraform.yml
+++ b/.github/workflows/continuous-integration-terraform.yml
@@ -63,9 +63,13 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
+      - name: Get branch name
+        id: branch-name
+        run: echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
+
       - name: Generate Terraform docs
         uses: terraform-docs/gh-actions@v1.0.0
-        if: "!startsWith(github.ref, 'refs/heads/renovate/')"
+        if: "!startsWith(steps.branch-name.outputs.branch, 'renovate/')"
         with:
           working-dir: .
           config-file: .terraform-docs.yml
@@ -75,7 +79,7 @@ jobs:
 
       - name: Generate Terraform docs for Renovate
         uses: terraform-docs/gh-actions@v1.0.0
-        if: "startsWith(github.ref, 'refs/heads/renovate/')"
+        if: "startsWith(steps.branch-name.outputs.branch, 'renovate/')"
         with:
           working-dir: .
           config-file: .terraform-docs.yml


### PR DESCRIPTION
* For PRs, `github.ref` returns the format `refs/pull/{pull_request_number}/merge`, which isn't what we want
* This fixes it by getting the branch name using `${GITHUB_REF#refs/heads/}` in a previous step, then checking the name in the terraform docs steps