### PR TITLE
Add `ref` for terraform-docs auto commit

### DIFF
--- a/.github/workflows/continuous-integration-terraform.yml
+++ b/.github/workflows/continuous-integration-terraform.yml
@@ -95,3 +95,4 @@ jobs:
           output-file: README.md
           output-method: inject
           git-push: true
+          ref: ${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
* This is listed as a requirement for auto-commits to work correctly. This may fix the issue with checks not running correctly