### PR TITLE
Use PAT for terraform-docs checkout action

### DIFF
--- a/.github/workflows/continuous-integration-terraform.yml
+++ b/.github/workflows/continuous-integration-terraform.yml
@@ -65,6 +65,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.TERRAFORM_DOCS_RENOVATE_WORKFLOW_GITHUB_TOKEN }}
 
       - name: Get PR base branch
         id: pr-base-branch-name


### PR DESCRIPTION
* To allow the auto-commit from terraform-docs to run the checks, a PAT needs to be used.