### PR TITLE
Add tfsec working directory

### DIFF
--- a/.github/workflows/continuous-integration-tfsec.yml
+++ b/.github/workflows/continuous-integration-tfsec.yml
@@ -12,3 +12,4 @@ jobs:
         uses: aquasecurity/tfsec-pr-commenter-action@v1.3.1
         with:
           github_token: ${{ github.token }}
+          working_directory: ''


### PR DESCRIPTION
* There is a bug in tfsec, where it finds vulnerabilities, but just outputs 'Ignoring - change not part of the current PR' - Even though it is. This is causing the check to pass, when it should fail.
* Adding `working_directory: ''` is a suggested fix
* https://github.com/aquasecurity/tfsec-pr-commenter-action/issues/90#issuecomment-1370985675