### PR TITLE
Fix terraform-docs Git commit message

### DIFF
--- a/.github/workflows/continuous-integration-terraform.yml
+++ b/.github/workflows/continuous-integration-terraform.yml
@@ -97,4 +97,4 @@ jobs:
           output-method: inject
           git-push: true
           ref: ${{ github.event.pull_request.head.ref }}
-          git-commit-message: "$GIT_COMMIT_MESSAGE - Terraform Docs"
+          git-commit-message: "${{ env.GIT_COMMIT_MESSAGE }} - Terraform Docs"


### PR DESCRIPTION
* To use environment variables in the action parameters, `env.` needs to be used rather than a shell variable (eg. `$VARIABLE`)