### PR TITLE
Create Glue database and tables for CloudTrail to be used with Athena

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ for dxw's Dalmatian hosting platform.
 | [aws_cloudtrail.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail) | resource |
 | [aws_cloudwatch_log_group.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.cloudwatch_slack_alerts_lambda_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_glue_catalog_database.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_catalog_database) | resource |
+| [aws_glue_catalog_table.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_catalog_table) | resource |
 | [aws_iam_policy.cloudtrail_cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.cloudtrail_cloudwatch_logs_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.cloudtrail_cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -83,6 +85,7 @@ for dxw's Dalmatian hosting platform.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region in which to launch resources | `string` | n/a | yes |
+| <a name="input_cloudtrail_athena_glue_tables"></a> [cloudtrail\_athena\_glue\_tables](#input\_cloudtrail\_athena\_glue\_tables) | Create the Glue database and tables for CloudTrail to be used with Athena | `bool` | n/a | yes |
 | <a name="input_cloudtrail_kms_encryption"></a> [cloudtrail\_kms\_encryption](#input\_cloudtrail\_kms\_encryption) | Use KMS encryption with CloudTrail | `bool` | n/a | yes |
 | <a name="input_cloudtrail_log_prefix"></a> [cloudtrail\_log\_prefix](#input\_cloudtrail\_log\_prefix) | Cloudtrail log prefix | `string` | n/a | yes |
 | <a name="input_cloudtrail_log_retention"></a> [cloudtrail\_log\_retention](#input\_cloudtrail\_log\_retention) | Cloudtrail log retention in days. Set to 0 to keep all logs. | `number` | n/a | yes |

--- a/cloudtrail-athena-glue-catalog.tf
+++ b/cloudtrail-athena-glue-catalog.tf
@@ -1,0 +1,40 @@
+resource "aws_glue_catalog_database" "cloudtrail" {
+  count = local.cloudtrail_athena_glue_tables ? 1 : 0
+
+  name        = "${replace(local.project_name, "-", "_")}_cloudtrail"
+  description = "Database for CloudTrail tables to be queried with Athena"
+}
+
+resource "aws_glue_catalog_table" "cloudtrail" {
+  count = local.cloudtrail_athena_glue_tables ? 1 : 0
+
+  name          = "cloudtrail_logs_${replace(aws_s3_bucket.cloudtrail[0].id, "-", "_")}_${aws_cloudtrail.cloudtrail[0].s3_key_prefix}"
+  database_name = aws_glue_catalog_database.cloudtrail[0].name
+
+  parameters = {
+    comment        = "CloudTrail table for ${aws_s3_bucket.cloudtrail[0].id} bucket"
+    EXTERNAL       = "TRUE"
+    classification = "cloudtrail"
+  }
+
+  storage_descriptor {
+    input_format  = "com.amazon.emr.cloudtrail.CloudTrailInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+    location      = "s3://${aws_s3_bucket.cloudtrail[0].id}/${aws_cloudtrail.cloudtrail[0].s3_key_prefix}/AWSLogs/${local.aws_account_id}/CloudTrail"
+
+    ser_de_info {
+      parameters = {
+        "serialization.format" = "1"
+      }
+      serialization_library = "org.apache.hive.hcatalog.data.JsonSerDe"
+    }
+
+    dynamic "columns" {
+      for_each = local.cloudtrail_glue_table_columns
+      content {
+        name = columns.key
+        type = columns.value
+      }
+    }
+  }
+}

--- a/locals.tf
+++ b/locals.tf
@@ -10,11 +10,38 @@ locals {
   tfvars_s3_tfvars_files                    = var.tfvars_s3_tfvars_files
   tfvars_s3_tfvars_restrict_access_user_ids = var.tfvars_s3_tfvars_restrict_access_user_ids
 
-  enable_cloudtrail         = var.enable_cloudtrail
-  cloudtrail_kms_encryption = var.cloudtrail_kms_encryption
-  cloudtrail_log_retention  = var.cloudtrail_log_retention
-  cloudtrail_log_prefix     = var.cloudtrail_log_prefix
-  cloudtrail_s3_access_logs = var.cloudtrail_s3_access_logs && local.enable_cloudtrail
+  enable_cloudtrail             = var.enable_cloudtrail
+  cloudtrail_kms_encryption     = var.cloudtrail_kms_encryption
+  cloudtrail_log_retention      = var.cloudtrail_log_retention
+  cloudtrail_log_prefix         = var.cloudtrail_log_prefix
+  cloudtrail_s3_access_logs     = var.cloudtrail_s3_access_logs && local.enable_cloudtrail
+  cloudtrail_athena_glue_tables = local.enable_cloudtrail && var.cloudtrail_athena_glue_tables
+  cloudtrail_glue_table_columns = {
+    eventversion        = "string",
+    useridentity        = "struct<type:string,principalId:string,arn:string,accountId:string,invokedBy:string,accessKeyId:string,userName:string,sessionContext:struct<attributes:struct<mfaAuthenticated:string,creationDate:string>creationDate:struct<type:string,principalId:string,arn:string,accountId:string,username:string>,ec2RoleDelivery:string,webIdFederationData:map<string,string>>>",
+    eventtime           = "string",
+    eventsource         = "string",
+    eventname           = "string",
+    awsregion           = "string",
+    sourceipaddress     = "string",
+    useragent           = "string",
+    errorcode           = "string",
+    errormessage        = "string",
+    requestparameters   = "string",
+    responseelements    = "string",
+    additionaleventdata = "string",
+    requestid           = "string",
+    eventid             = "string",
+    resources           = "array<struct<arn:string,accountId:string,type:string>>",
+    eventtype           = "string",
+    apiversion          = "string",
+    readonly            = "string",
+    recipientaccountid  = "string",
+    serviceeventdetails = "string",
+    sharedeventid       = "string",
+    vpcendpointid       = "string",
+    tlsdetails          = "struct<tlsVersion:string,cipherSuite:string,clientProvidedHostHeader:string>"
+  }
 
   enable_cloudwatch_slack_alerts         = var.enable_cloudwatch_slack_alerts
   cloudwatch_slack_alerts_kms_encryption = var.cloudwatch_slack_alerts_kms_encryption && local.enable_cloudwatch_slack_alerts

--- a/variables.tf
+++ b/variables.tf
@@ -68,6 +68,11 @@ variable "cloudtrail_s3_access_logs" {
   type        = bool
 }
 
+variable "cloudtrail_athena_glue_tables" {
+  description = "Create the Glue database and tables for CloudTrail to be used with Athena"
+  type        = bool
+}
+
 variable "enable_cloudwatch_slack_alerts" {
   description = "Enable CloudWatch Slack alerts. This creates an SNS topic to which alerts and pipelines can send messages, which are then picked up by a Lambda function that forwards them to a Slack webhook."
   type        = bool


### PR DESCRIPTION
* Allows us to query the CloudTrail logs with Athena
* CloudTrail logs by default are stored in an S3 bucket, in a structure that makes it difficult to read or query. Creating the Glue table (with a structure that works with the CloudTrail logs) allows Athena to read and query the logs.