### PR TITLE
Add CodeStar connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ for dxw's Dalmatian hosting platform.
 | [aws_cloudtrail.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail) | resource |
 | [aws_cloudwatch_log_group.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.cloudwatch_slack_alerts_lambda_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_codestarconnections_connection.connections](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codestarconnections_connection) | resource |
 | [aws_glue_catalog_database.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_catalog_database) | resource |
 | [aws_glue_catalog_table.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_catalog_table) | resource |
 | [aws_iam_policy.cloudtrail_cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -109,6 +110,7 @@ for dxw's Dalmatian hosting platform.
 | <a name="input_cloudwatch_slack_alerts_hook_url"></a> [cloudwatch\_slack\_alerts\_hook\_url](#input\_cloudwatch\_slack\_alerts\_hook\_url) | The Slack webhook URL for CloudWatch alerts | `string` | n/a | yes |
 | <a name="input_cloudwatch_slack_alerts_kms_encryption"></a> [cloudwatch\_slack\_alerts\_kms\_encryption](#input\_cloudwatch\_slack\_alerts\_kms\_encryption) | Use KMS encryption with the Slack Alerts SNS topic and logs | `bool` | n/a | yes |
 | <a name="input_cloudwatch_slack_alerts_log_retention"></a> [cloudwatch\_slack\_alerts\_log\_retention](#input\_cloudwatch\_slack\_alerts\_log\_retention) | Cloudwatch Slack Alerts log retention. Set to 0 to keep all logs | `number` | n/a | yes |
+| <a name="input_codestar_connections"></a> [codestar\_connections](#input\_codestar\_connections) | CodeStar connections to create | <pre>map(<br>    object({<br>      provider_type = string,<br>    })<br>  )</pre> | n/a | yes |
 | <a name="input_enable_cloudtrail"></a> [enable\_cloudtrail](#input\_enable\_cloudtrail) | Enable Cloudtrail | `bool` | n/a | yes |
 | <a name="input_enable_cloudwatch_opsgenie_alerts"></a> [enable\_cloudwatch\_opsgenie\_alerts](#input\_enable\_cloudwatch\_opsgenie\_alerts) | Enable CloudWatch Opsgenie alerts. This creates an SNS topic to which alerts and pipelines can send messages, which are then sent to the Opsgenie SNS endpoint. | `bool` | n/a | yes |
 | <a name="input_enable_cloudwatch_slack_alerts"></a> [enable\_cloudwatch\_slack\_alerts](#input\_enable\_cloudwatch\_slack\_alerts) | Enable CloudWatch Slack alerts. This creates an SNS topic to which alerts and pipelines can send messages, which are then picked up by a Lambda function that forwards them to a Slack webhook. | `bool` | n/a | yes |

--- a/codestar-connections.tf
+++ b/codestar-connections.tf
@@ -1,0 +1,5 @@
+resource "aws_codestarconnections_connection" "connections" {
+  for_each      = local.codestar_connections
+  name          = "${substr(local.project_name, 0, 31 - length(each.key))}-${each.key}"
+  provider_type = each.value["provider_type"]
+}

--- a/locals.tf
+++ b/locals.tf
@@ -55,6 +55,8 @@ locals {
   cloudwatch_opsgenie_alerts_sns_kms_encryption = var.cloudwatch_opsgenie_alerts_sns_kms_encryption && local.enable_cloudwatch_opsgenie_alerts
   cloudwatch_opsgenie_alerts_sns_endpoint       = var.cloudwatch_opsgenie_alerts_sns_endpoint
 
+  codestar_connections = var.codestar_connections
+
   enable_logs_bucket       = local.cloudtrail_s3_access_logs || local.cloudtrail_athena_glue_tables
   logging_bucket_retention = var.logging_bucket_retention
   logs_bucket_source_arns = concat(

--- a/variables.tf
+++ b/variables.tf
@@ -123,6 +123,15 @@ variable "cloudwatch_opsgenie_alerts_sns_kms_encryption" {
   type        = bool
 }
 
+variable "codestar_connections" {
+  description = "CodeStar connections to create"
+  type = map(
+    object({
+      provider_type = string,
+    })
+  )
+}
+
 variable "logging_bucket_retention" {
   description = "Logging bucket retention in days. Set to 0 to keep all logs."
   type        = number


### PR DESCRIPTION
* Generally we will only need of of these per account, so that we can link CodePipelines to our GitHub account.
* It has however been configured to allow us to create multiple CodeStar connections, in case we need more in the future