### PR TITLE
Fix CloudWatch Slack alerts logs policy resource name

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ for dxw's Dalmatian hosting platform.
 | [aws_glue_catalog_database.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_catalog_database) | resource |
 | [aws_glue_catalog_table.cloudtrail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/glue_catalog_table) | resource |
 | [aws_iam_policy.cloudtrail_cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.cloudtrail_cloudwatch_logs_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.cloudwatch_slack_alerts_logs_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.cloudtrail_cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.cloudwatch_slack_alerts_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.cloudtrail_cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.cloudtrail_cloudwatch_logs_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cloudwatch_slack_alerts_logs_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_kms_alias.athena_cloudtrail_output](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.cloudtrail_cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.cloudwatch_opsgenie_alerts_sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |

--- a/cloudwatch-slack-alerts-lambda.tf
+++ b/cloudwatch-slack-alerts-lambda.tf
@@ -16,7 +16,7 @@ resource "aws_iam_role" "cloudwatch_slack_alerts_lambda" {
   )
 }
 
-resource "aws_iam_policy" "cloudtrail_cloudwatch_logs_lambda" {
+resource "aws_iam_policy" "cloudwatch_slack_alerts_logs_lambda" {
   count = local.enable_cloudwatch_slack_alerts ? 1 : 0
 
   name = "${local.project_name}-cloudwatch-slack-alerts-lambda"
@@ -30,11 +30,11 @@ resource "aws_iam_policy" "cloudtrail_cloudwatch_logs_lambda" {
   )
 }
 
-resource "aws_iam_role_policy_attachment" "cloudtrail_cloudwatch_logs_lambda" {
+resource "aws_iam_role_policy_attachment" "cloudwatch_slack_alerts_logs_lambda" {
   count = local.enable_cloudwatch_slack_alerts ? 1 : 0
 
   role       = aws_iam_role.cloudwatch_slack_alerts_lambda[0].name
-  policy_arn = aws_iam_policy.cloudtrail_cloudwatch_logs_lambda[0].arn
+  policy_arn = aws_iam_policy.cloudwatch_slack_alerts_logs_lambda[0].arn
 }
 
 data "archive_file" "cloudwatch_slack_alerts_lambda" {


### PR DESCRIPTION
* The resource name should be `cloudwatch_slack_alerts_logs_lambda` rather than `cloudtrail_cloudwatch_logs_lambda`