### PR TITLE
Fix: Role name lengths

### DIFF
--- a/cloudtrail.tf
+++ b/cloudtrail.tf
@@ -62,7 +62,8 @@ resource "aws_cloudwatch_log_group" "cloudtrail" {
 resource "aws_iam_role" "cloudtrail_cloudwatch_logs" {
   count = local.enable_cloudtrail ? 1 : 0
 
-  name = "${local.project_name}-cloudtrail-cloudwatch-logs"
+  name        = "${local.project_name}-${substr(sha512("cloudtrail-cloudwatch-logs"), 0, 6)}"
+  description = "${local.project_name}-cloudtrail-cloudwatch-logs"
   assume_role_policy = templatefile(
     "${path.root}/policies/service-assume.json.tpl",
     { service = "cloudtrail.amazonaws.com" }

--- a/cloudwatch-slack-alerts-lambda.tf
+++ b/cloudwatch-slack-alerts-lambda.tf
@@ -9,7 +9,8 @@ resource "aws_cloudwatch_log_group" "cloudwatch_slack_alerts_lambda_log_group" {
 resource "aws_iam_role" "cloudwatch_slack_alerts_lambda" {
   count = local.enable_cloudwatch_slack_alerts ? 1 : 0
 
-  name = "${local.project_name}-cloudwatch-slack-alerts-lambda"
+  name        = "${local.project_name}-${substr(sha512("cloudwatch-slack-alerts-lambda"), 0, 6)}"
+  description = "${local.project_name}-cloudwatch-slack-alerts-lambda"
   assume_role_policy = templatefile(
     "${path.root}/policies/service-assume.json.tpl",
     { service = "lambda.amazonaws.com" }


### PR DESCRIPTION
* A role name can only be 64 characters
* This fix uses a hash of the role suffix instead of the full name, and then adds the full name as a description.