### PR TITLE
Allow Slack Alerts KMS encrypt on Slack Alerts CMK

### DIFF
--- a/cloudwatch-slack-alerts-sns.tf
+++ b/cloudwatch-slack-alerts-sns.tf
@@ -23,6 +23,11 @@ resource "aws_kms_key" "cloudwatch_slack_alerts" {
       {
         log_group_arn = "arn:aws:logs:${local.aws_region}:${local.aws_account_id}:log-group:/aws/lambda/${local.project_name}-cloudwatch-to-slack"
       }
+      )},
+      ${templatefile("${path.root}/policies/kms-key-policy-statements/service-allow-encrypt.json.tpl",
+      {
+        services = jsonencode(["events.amazonaws.com"])
+      }
   )}
       ]
       EOT

--- a/policies/kms-key-policy-statements/service-allow-encrypt.json.tpl
+++ b/policies/kms-key-policy-statements/service-allow-encrypt.json.tpl
@@ -1,0 +1,11 @@
+{
+  "Effect": "Allow",
+  "Principal": {
+    "Service": ${services}
+  },
+  "Action": [
+    "kms:GenerateDataKey*",
+    "kms:Decrypt"
+  ],
+  "Resource": "*"
+}


### PR DESCRIPTION
* `events.amazonaws.com` needs permission to use the KMS CMK to encrypt data through to the SNS topic, when sending messages from CloudWatch