### PR TITLE
Fix CloudWatch Slack Alerts Lambda message format

### DIFF
--- a/lambdas/cloudwatch-slack-alerts/function.py
+++ b/lambdas/cloudwatch-slack-alerts/function.py
@@ -17,8 +17,11 @@ def lambda_handler(event, context):
     try:
       message = json.loads(event['Records'][0]['Sns']['Message'])
     except ValueError as e:
-      message = '{"message": "%s"}' (event['Records'][0]['Sns']['Message'].replace('"', '\\"'))
-    return True
+      message = { "message": event['Records'][0]['Sns']['Message'] }
+
+    if isinstance(message, str):
+      message = { "message": event['Records'][0]['Sns']['Message'] }
+
     logger.info("Message: " + str(message))
 
     if "AlarmName" in message.keys():


### PR DESCRIPTION
* Creates a dict rather than creating a JSON string and loading it
* Checks if the message result is a string, and creates a dict if it is
* Removes the 'return True', which is causing the function to exit early